### PR TITLE
Fix blending icons with background color

### DIFF
--- a/src/FSFileButton.c
+++ b/src/FSFileButton.c
@@ -75,7 +75,7 @@ static void destroyFSFileButton(_FSFileButton* bPtr);
 /* static void resizeFSFileButton(WMWidget*, unsigned int, unsigned int); */
 static void paintImageAndText(W_View* view, int x, int y,
     int width, int height,
-    char* imgName, char* text, GC backGC);
+    char* imgName, char* text, WMColor* back);
 static void radioPushObserver(void* observerData, WMNotification* notification);
 static void showTextView(FSFileButton* bPtr);
 static W_View* createTextView(W_Screen* scr, char* text, int width, int len);
@@ -240,7 +240,7 @@ paintFSFileButton(_FSFileButton* bPtr)
 
     if (bPtr->flags.cleared) {
         paintImageAndText(bPtr->view, 0, 0, bPtr->width, bPtr->height,
-            NULL, NULL, WMColorGC(bPtr->view->screen->white));
+            NULL, NULL, bPtr->view->screen->white);
         return;
     }
     if (bPtr->paintTimer)
@@ -265,7 +265,7 @@ paintFSFileButton(_FSFileButton* bPtr)
     if (bPtr->flags.selected || bPtr->flags.extSelected)
         paintImageAndText(bPtr->view, 0, 0, bPtr->width, bPtr->height,
             bPtr->fileInfo->imgName, bPtr->fileInfo->name,
-            WMColorGC(bPtr->view->screen->white));
+            bPtr->view->screen->white);
     else
         paintImageAndText(bPtr->view, 0, 0, bPtr->width, bPtr->height,
             bPtr->fileInfo->imgName, bPtr->fileInfo->name,
@@ -440,7 +440,7 @@ static void roundedRect(Display* dpy, Drawable d, GC backGC, int x, int y, int w
 
 static void
 paintImageAndText(W_View* view, int x, int y, int width, int height,
-    char* imgName, char* text, GC backGC)
+    char* imgName, char* text, WMColor* back)
 {
     int strwidth = 1;
     RColor color;
@@ -449,10 +449,13 @@ paintImageAndText(W_View* view, int x, int y, int width, int height,
     W_Screen* screen = view->screen;
     Drawable d = view->window;
 
-    color.red = 0xae;
-    color.green = 0xaa;
-    color.blue = 0xae;
-    color.alpha = 0;
+    if (back) {
+        color = WMGetRColorFromColor(back);
+    } else {
+        WMColor *gray = WMGrayColor(screen);
+        color = WMGetRColorFromColor(gray);
+        WMReleaseColor(gray);
+    }
 
     /*
      * Clear the area we are painting on
@@ -473,22 +476,20 @@ paintImageAndText(W_View* view, int x, int y, int width, int height,
     // W_DrawRelief(screen, d, x, y, width, height, RRaisedBevel);
 
     /* background */
-    if (backGC) {
+    if (back) {
         // image = FSCreatePixmapWithBackingFromFile(screen, imgName, &color);
-        roundedRect(screen->display, d, backGC,
+        roundedRect(screen->display, d, WMColorGC(back),
             x + (width - BUTTON_WIDTH) / 2, y + (height - BUTTON_HEIGHT - LABEL_HEIGHT) / 2,
             BUTTON_WIDTH, BUTTON_HEIGHT);
         /* text background rectangle */
         if (text)
-            XFillRectangle(screen->display, d, backGC,
+            XFillRectangle(screen->display, d, WMColorGC(back),
                 x + (width - strwidth) / 2, y + (height - BUTTON_HEIGHT - LABEL_HEIGHT) / 2 + BUTTON_HEIGHT,
                 strwidth, LABEL_HEIGHT);
     }
-    // else
-    //{        /* FS.. */
-    image = WMCreateBlendedPixmapFromFile(screen, imgName, &color);
-    //}
-
+    
+    image = FSCreateBlendedPixmapFromFile(screen, imgName, back);
+    
     if (image) {
         WMDrawPixmap(image, d, x + (width - image->width) / 2, y + (height - image->height) / 2 - LABEL_HEIGHT / 2);
         WMReleasePixmap(image);

--- a/src/FSInspector.c
+++ b/src/FSInspector.c
@@ -100,13 +100,7 @@ static void
 FSUpdateInspectorFileInfoDisplay(FSInspector* fsInspector)
 {
     char* buf;
-    RColor color;
     WMPixmap* pixmap;
-
-    color.red = 0xae;
-    color.green = 0xaa; /* aa ?*/
-    color.blue = 0xae;
-    color.alpha = 0;
 
     if (fsInspector->fileInfo->fileType != ROOT)
         WMSetLabelText(fsInspector->nameLabel, fsInspector->fileInfo->name);
@@ -116,10 +110,8 @@ FSUpdateInspectorFileInfoDisplay(FSInspector* fsInspector)
         tmp = FSNodeName();
         WMSetLabelText(fsInspector->nameLabel, tmp);
     }
-    /* why FS... */
-    pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(fsInspector->win),
-        fsInspector->fileInfo->imgName,
-        &color);
+
+    pixmap = FSCreateBlendedPixmapFromFile(WMWidgetScreen(fsInspector->win), fsInspector->fileInfo->imgName, NULL);
     WMSetLabelImage(fsInspector->nameLabel, pixmap);
 
     buf = (char*)wmalloc(strlen(_("Path: ")) + strlen(fsInspector->fileInfo->path) + 1);

--- a/src/FSPanel.c
+++ b/src/FSPanel.c
@@ -104,7 +104,7 @@ FSCreateInfoPanel(FSViewer* app, char* title, char* msg)
     WMSetWindowTitle(info->win, _("Info"));
     WMSetWindowCloseAction(info->win, FSCloseInfoPanel, (void*)info);
 
-    if ((appicon = WMGetApplicationIconPixmap(info->scr))) {
+    if ((appicon = FSCreateBlendedPixmapFromFile(info->scr, LocateImage("FSViewer"), NULL))) {
         WMSize appIconSize;
 
         appIconSize = WMGetPixmapSize(appicon);

--- a/src/FSPanel.c
+++ b/src/FSPanel.c
@@ -1382,7 +1382,6 @@ FSCreateSelectIconPanel(WMWindow* owner, char* title, char* str)
     int height, width, offset;
     WMFrame* f;
     WMLabel* l;
-    RColor color;
     WMPixmap* pixmap;
     char* txt = NULL;
     WMFont* aFont;
@@ -1427,13 +1426,8 @@ FSCreateSelectIconPanel(WMWindow* owner, char* title, char* str)
     l = WMCreateLabel(selIcon->frame);
     WMResizeWidget(l, width - 10, 75);
     WMMoveWidget(l, 10, 10);
-    color.red = 0xae;
-    color.green = 0xaa;
-    color.blue = 0xae;
-    color.alpha = 0;
-    /* FS.. */
-    pixmap = WMCreateBlendedPixmapFromFile(selIcon->scr, LocateImage(str),
-        &color);
+
+    pixmap = FSCreateBlendedPixmapFromFile(selIcon->scr, LocateImage(str), NULL);
     WMSetLabelImage(l, pixmap);
     WMSetLabelText(l, str);
     WMSetLabelImagePosition(l, WIPLeft);
@@ -1553,22 +1547,13 @@ selIconButtonClick(WMWidget* self, void* data)
 static void
 setIconLabel(WMWidget* self, void* data)
 {
-    RColor color;
     WMPixmap* pixmap;
     FSSelectIconPanel* panel = (FSSelectIconPanel*)data;
-
-    color.red = 0xae;
-    color.green = 0xaa;
-    color.blue = 0xae;
-    color.alpha = 0;
 
     if (panel->iconName)
         free(panel->iconName);
     panel->iconName = getSelectedFilename(panel);
-    /* FS.. */
-    pixmap = WMCreateBlendedPixmapFromFile(panel->scr,
-        LocateImage(panel->iconName),
-        &color);
+    pixmap = FSCreateBlendedPixmapFromFile(panel->scr, LocateImage(panel->iconName), NULL);
     WMSetLabelImage(panel->iconLabel, pixmap);
 }
 
@@ -1616,13 +1601,7 @@ char* getSelectedFilename(FSSelectIconPanel* panel)
 
     listItem = WMGetListSelectedItem(panel->fileList);
     if (listItem) {
-        RColor color;
         WMPixmap* pixmap;
-
-        color.red = 0xae;
-        color.green = 0xaa;
-        color.blue = 0xae;
-        color.alpha = 0;
 
         fileInfo = (FileInfo*)listItem->clientData;
 
@@ -1632,9 +1611,7 @@ char* getSelectedFilename(FSSelectIconPanel* panel)
             filename = GetPathnameFromPathName(fileInfo->path, fileInfo->name);
 
         imgName = LocateImage(filename);
-        /*  FS.. */
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win),
-            imgName, &color);
+        pixmap = FSCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win), imgName, NULL);
 
         WMSetLabelImage(panel->iconLabel, pixmap);
         WMReleasePixmap(pixmap);

--- a/src/FSUtils.c
+++ b/src/FSUtils.c
@@ -553,18 +553,13 @@ void LaunchApp(FSViewer* fsViewer, FileInfo* fileInfo, AppEvent event)
 
 void FSSetButtonImageFromFile(WMButton* btn, char* imgName)
 {
-    RColor color;
     WMPixmap* pixmap;
 
-    color.red = 0xae;
-    color.green = 0xaa; /* aa ?*/
-    color.blue = 0xae;
-    color.alpha = 0;
-    if (imgName)
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(btn),
-            imgName, &color);
-    else
+    if (imgName) {
+        pixmap = FSCreateBlendedPixmapFromFile(WMWidgetScreen(btn), imgName, NULL);
+    } else {
         pixmap = NULL;
+    }
 
     if (!pixmap) {
         wwarning(_("%s %d: Could not load icon file %s"),
@@ -574,17 +569,13 @@ void FSSetButtonImageFromFile(WMButton* btn, char* imgName)
         WMReleasePixmap(pixmap);
     }
 
-    color.red = 0xff;
-    color.green = 0xff;
-    color.blue = 0xff;
-    color.alpha = 0;
-    if (imgName)
-        /*	pixmap = FSCreatePixmapWithBackingFromFile(WMWidgetScreen(btn),
-                                                           imgName, &color);*/
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(btn),
-            imgName, &color);
-    else
+    if (imgName) {
+        WMColor* white = WMWhiteColor(WMWidgetScreen(btn));
+        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(btn), imgName, white);
+        WMReleaseColor(white);
+    } else {
         pixmap = NULL;
+    }
 
     if (!pixmap) {
         wwarning(_("%s %d: Could not load icon file %s"),
@@ -597,13 +588,8 @@ void FSSetButtonImageFromFile(WMButton* btn, char* imgName)
 
 void FSSetButtonImageFromXPMData(WMButton* btn, char** data)
 {
-    RColor color;
     WMPixmap* pixmap;
 
-    color.red = 0xae;
-    color.green = 0xaa;
-    color.blue = 0xae;
-    color.alpha = 0;
     pixmap = WMCreatePixmapFromXPMData(WMWidgetScreen(btn), data);
     if (!pixmap)
         wwarning(_("%s %d: Could not create Pixmap from Data"),
@@ -614,10 +600,6 @@ void FSSetButtonImageFromXPMData(WMButton* btn, char** data)
     if (pixmap)
         WMReleasePixmap(pixmap);
 
-    color.red = 0xff;
-    color.green = 0xff;
-    color.blue = 0xff;
-    color.alpha = 0;
     pixmap = WMCreatePixmapFromXPMData(WMWidgetScreen(btn), data);
     if (!pixmap)
         wwarning(_("%s %d: Could not create Pixmap from Data"),
@@ -809,49 +791,20 @@ int FSStringMatch(char* pattern, char* fn)
             return 1;
     };
 }
-/*
-WMPixmap*
-FSCreateBlendedPixmapFromFile(WMScreen *scr, char *fileName, RColor *color)
-{
-    RImage *image = NULL;
-    RImage *clone = NULL;
-    WMPixmap *pixmap;
-    RColor color1;
-    int x,y;
 
-    if(!rContext)
-    {
-        memset((void *) &attributes, 0, sizeof(RContextAttributes));
-        attributes.flags = (RC_RenderMode | RC_ColorsPerChannel);
-        attributes.render_mode = RM_DITHER;
-        attributes.colors_per_channel = 4;
+WMPixmap *FSCreateBlendedPixmapFromFile(WMScreen *scr, char *fileName, WMColor *color) {
+    RColor bgCol;
 
-        rContext = RCreateContext(WMScreenDisplay(scr),
-                                  DefaultScreen(WMScreenDisplay(scr)),
-                                  &attributes);
+    if (color) {
+        bgCol = WMGetRColorFromColor(color);
+    } else {
+        WMColor *gray = WMGrayColor(scr);
+        bgCol = WMGetRColorFromColor(gray);
+        WMReleaseColor(gray);
     }
-    if(fileName)
-        image = RLoadImage(rContext, fileName, 0);
-    if(!image)
-        image = RGetImageFromXPMData(rContext, file_plain);
 
-    color1.red   = 0xa3;
-    color1.green = 0xa3;
-    color1.blue  = 0xa3;
-    color1.alpha = 255;
-
-    RCombineImageWithColor(image, color);
-
-    / * Resize the width to 64x64 pixels * /
-    clone = RMakeCenteredImage(image, 64, 64, &color1);
-    pixmap = WMCreatePixmapFromRImage(scr, clone, 0);
-
-    RReleaseImage(image);
-    RReleaseImage(clone);
-
-    return pixmap;
+    return WMCreateBlendedPixmapFromFile(scr, fileName, &bgCol);
 }
-*/
 
 WMPixmap*
 FSCreatePixmapWithBackingFromFile(WMScreen* scr, char* fileName, RColor* color)

--- a/src/FSUtils.h
+++ b/src/FSUtils.h
@@ -23,8 +23,7 @@ mode_t FSGetUMask();
 void FSUpdateFileView();
 char* FSGetHomeDir();
 int FSStringMatch(char* pattern, char* fn);
-WMPixmap* FSCreateBlendedPixmapFromFile(WMScreen* scr, char* fileName,
-    RColor* color);
+WMPixmap* FSCreateBlendedPixmapFromFile(WMScreen* scr, char* fileName, WMColor* color);
 WMPixmap* FSCreatePixmapWithBackingFromFile(WMScreen* scr, char* fileName,
     RColor* color);
 WMPixmap* FSCreateBlurredPixmapFromFile(WMScreen* scr, char* fileName);

--- a/src/editInspector.c
+++ b/src/editInspector.c
@@ -120,16 +120,8 @@ appListClick(WMWidget* self, void* data)
     exec = FSGetStringForNameKey(selected, "exec");
 
     if (icon) {
-        RColor color;
-        WMPixmap* pixmap;
+        WMPixmap* pixmap = FSCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win), icon, NULL);
 
-        color.red = 0xae;
-        color.green = 0xaa;
-        color.blue = 0xae;
-        color.alpha = 0;
-        /* FS.. */
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win),
-            icon, &color);
         if (pixmap) {
             WMSetButtonImagePosition(panel->appBtn, WIPImageOnly);
             WMSetButtonImage(panel->appBtn, pixmap);

--- a/src/iconInspector.c
+++ b/src/iconInspector.c
@@ -42,22 +42,13 @@ static char* getSelectedFilename(_Panel* panel);
 static void
 setIconLabel(WMWidget* self, void* data)
 {
-    RColor color;
     WMPixmap* pixmap;
     _Panel* panel = (_Panel*)data;
-
-    color.red = 0xae;
-    color.green = 0xaa;
-    color.blue = 0xae;
-    color.alpha = 0;
 
     if (panel->iconName)
         free(panel->iconName);
     panel->iconName = getSelectedFilename(panel);
-    /* FS.. */
-    pixmap = WMCreateBlendedPixmapFromFile(panel->scr,
-        LocateImage(panel->iconName),
-        &color);
+    pixmap = FSCreateBlendedPixmapFromFile(panel->scr, LocateImage(panel->iconName), NULL);
     WMSetLabelImage(panel->iconLabel, pixmap);
 }
 
@@ -107,13 +98,7 @@ getSelectedFilename(_Panel* panel)
 
     listItem = WMGetListSelectedItem(panel->fileList);
     if (listItem) {
-        RColor color;
         WMPixmap* pixmap;
-
-        color.red = 0xae;
-        color.green = 0xaa;
-        color.blue = 0xae;
-        color.alpha = 0;
 
         fileInfo = (FileInfo*)listItem->clientData;
 
@@ -123,9 +108,7 @@ getSelectedFilename(_Panel* panel)
             filename = GetPathnameFromPathName(fileInfo->path, fileInfo->name);
 
         imgName = LocateImage(filename);
-        /* FS..*/
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win),
-            imgName, &color);
+        pixmap = FSCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win), imgName, NULL);
 
         WMSetLabelImage(panel->iconLabel, pixmap);
         WMReleasePixmap(pixmap);
@@ -141,17 +124,9 @@ static void
 showData(_Panel* panel)
 {
     char* file;
-    RColor color;
     WMPixmap* pixmap;
 
-    color.red = 0xae;
-    color.green = 0xaa;
-    color.blue = 0xae;
-    color.alpha = 0;
-    /* FS..*/
-    pixmap = WMCreateBlendedPixmapFromFile(panel->scr,
-        panel->fileInfo->imgName,
-        &color);
+    pixmap = FSCreateBlendedPixmapFromFile(panel->scr, panel->fileInfo->imgName, NULL);
     WMClearList(panel->pathList);
     WMClearList(panel->fileList);
 

--- a/src/viewInspector.c
+++ b/src/viewInspector.c
@@ -119,16 +119,9 @@ appListClick(WMWidget* self, void* data)
     exec = FSGetStringForNameKey(selected, "exec");
 
     if (icon) {
-        RColor color;
         WMPixmap* pixmap;
 
-        color.red = 0xae;
-        color.green = 0xaa;
-        color.blue = 0xae;
-        color.alpha = 0;
-        /* FS.. */
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win),
-            icon, &color);
+        pixmap = FSCreateBlendedPixmapFromFile(WMWidgetScreen(panel->win), icon, NULL);
         if (pixmap) {
             WMSetButtonImagePosition(panel->appBtn, WIPImageOnly);
             WMSetButtonImage(panel->appBtn, pixmap);


### PR DESCRIPTION
This PR fixes blending an icon's alpha channel with the default widget background color (or white in case of an active selection).