### PR TITLE
files: Fix crash with Umlaut dir entries on macOS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - Fix secondary windows to being resizable. ([#15](https://github.com/roblillack/fsviewer/pull/15))
 - Fix showing correct free disk space with SI prefixes. ([#17](https://github.com/roblillack/fsviewer/pull/17))
 - Fix alpha channel blending for icons everywhere. ([#18](https://github.com/roblillack/fsviewer/pull/18))
+- Fix crash when when directory contains Umlaut entries on macOS ([#21](https://github.com/roblillack/fsviewer/pull/21))
 
 ## FSViewer 0.2.7 (2024-06-22)
 


### PR DESCRIPTION
Includes a workaround for umlaut extenions (which are ignored).

Ticket: #20