### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/FSBrowser.c
+++ b/src/FSBrowser.c
@@ -1,6 +1,7 @@
 #include <WINGs/WINGsP.h>
 #include <WMaker.h>
 #include <math.h> /* for : double rint (double) */
+#include <stdint.h>
 
 #include "FSBrowser.h"
 
@@ -174,7 +175,7 @@ void FSSetBrowserMaxVisibleColumns(FSBrowser* bPtr, int columns)
     int curMaxVisibleColumns;
     int newFirstVisibleColumn = 0;
 
-    assert((int)bPtr);
+    assert(bPtr);
 
     columns = (columns < MIN_VISIBLE_COLUMNS) ? MIN_VISIBLE_COLUMNS : columns;
     columns = (columns > MAX_VISIBLE_COLUMNS) ? MAX_VISIBLE_COLUMNS : columns;
@@ -320,7 +321,7 @@ removeColumn(FSBrowser* bPtr, int column)
     WMList** clist;
     char** tlist;
 
-    assert((int)bPtr);
+    assert(bPtr);
 
     column = (column < 0) ? 0 : column;
     if (column >= bPtr->columnCount) {
@@ -690,6 +691,8 @@ scrollCallback(WMWidget* scroller, void* self)
 
     } break;
 
+    case WSDecrementWheel:
+    case WSIncrementWheel:
     case WSKnobSlot:
     case WSNoPart:
         /* do nothing */
@@ -833,18 +836,19 @@ char* FSGetBrowserPathToColumn(FSBrowser* bPtr, int column)
     }
 
     /* get the path */
-    path = wmalloc(size + (column + 1) * strlen(bPtr->pathSeparator) + 1);
+    size_t pathSize = size + (column + 1) * strlen(bPtr->pathSeparator) + 1;
+    path = wmalloc(pathSize);
     /* ignore first / */
     *path = 0;
     for (i = 0; i <= column; i++) {
-        strcat(path, bPtr->pathSeparator);
+        strlcat(path, bPtr->pathSeparator, pathSize);
         item = WMGetListSelectedItem(bPtr->columns[i]);
         if (!item)
             break;
         /* 	if(bPtr->parseItem) */
-        /* 	    strcat(path, (*bPtr->parseItem)(item)); */
+        /* 	    strlcat(path, (*bPtr->parseItem)(item), pathSize); */
         /* 	else */
-        strcat(path, item->text);
+        strlcat(path, item->text, pathSize);
     }
 
     return path;
@@ -1072,7 +1076,7 @@ static void
 listSelectionObserver(void* observerData, WMNotification* notification)
 {
     FSBrowser* bPtr = (FSBrowser*)observerData;
-    int column, item = (int)WMGetNotificationClientData(notification);
+    int column, item = (int)(intptr_t)WMGetNotificationClientData(notification);
     WMList* lPtr = (WMList*)WMGetNotificationObject(notification);
 
     for (column = 0; column < bPtr->usedColumnCount; column++)
@@ -1177,23 +1181,24 @@ static char*
 createTruncatedString(WMFont* font, char* text, int* textLen, int width)
 {
     int dLen = WMWidthOfString(font, ".", 1);
-    char* textBuf = (char*)wmalloc((*textLen) + 4);
+    size_t bufSize = (*textLen) + 4;
+    char* textBuf = (char*)wmalloc(bufSize);
 
     if (width >= 3 * dLen) {
         int dddLen = 3 * dLen;
         int tmpTextLen = *textLen;
 
-        strcpy(textBuf, text);
+        strlcpy(textBuf, text, bufSize);
         while (tmpTextLen
             && (WMWidthOfString(font, textBuf, tmpTextLen) + dddLen > width))
             tmpTextLen--;
-        strcpy(textBuf + tmpTextLen, "...");
+        strlcpy(textBuf + tmpTextLen, "...", bufSize - tmpTextLen);
         *textLen = tmpTextLen + 3;
     } else if (width >= 2 * dLen) {
-        strcpy(textBuf, "..");
+        strlcpy(textBuf, "..", bufSize);
         *textLen = 2;
     } else if (width >= dLen) {
-        strcpy(textBuf, ".");
+        strlcpy(textBuf, ".", bufSize);
         *textLen = 1;
     } else {
         *textBuf = '\0';

--- a/src/FSFileView.c
+++ b/src/FSFileView.c
@@ -313,7 +313,7 @@ FSCreateFileView(FSViewer* fsViewer, char* path, Bool primary)
 
     fView->fileView = WMCreateWindow(fView->scr, "fileView");
     WMSetWindowTitle(fView->fileView, _("FileView"));
-    if ((fView->primary == False)) {
+    if (fView->primary == False) {
         WMSetWindowCloseAction(fView->fileView, FSDestroyFileView,
             (void*)fView);
     }
@@ -415,7 +415,7 @@ FSCreateFileView(FSViewer* fsViewer, char* path, Bool primary)
         fView->size->width_inc = cw + COLUMN_PADDING;
         fView->size->height_inc = 1;
         fView->size->flags = (USSize | PSize | PMinSize | PMaxSize | PResizeInc);
-        if ((fView->primary == True)) {
+        if (fView->primary == True) {
             fView->size->x = fView->x;
             fView->size->y = fView->y;
             fView->size->flags |= (USPosition | PPosition);
@@ -563,6 +563,7 @@ void FSUpdateFileViewPath(FSFileView* fileView, FileAction action,
 
     switch (action) {
     case FileCopy:
+    case FileLink:
         FSUpdateFileBrowser(fileView->fileBrowser, action, src, dest);
         break;
     case FileMove:

--- a/src/FSFinder.c
+++ b/src/FSFinder.c
@@ -6,6 +6,7 @@
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -207,7 +208,7 @@ notificationObserver(void* self, WMNotification* notif)
             WMResizeWidget(finder->list,
                 finder->w - (PADY * 2), finder->h - LISTX - (PADY * 2));
         }
-    } else if ((int)WMGetNotificationClientData(notif) == WMReturnTextMovement) {
+    } else if ((int)(intptr_t)WMGetNotificationClientData(notif) == WMReturnTextMovement) {
         populateList(finder);
     }
 }
@@ -231,15 +232,18 @@ populateList(FSFinder* finder)
      * and the second should be 0, maybe it's LIFO
      */
     if (WMGetButtonSelected(finder->findRadioBtns[0]) == 1) {
-        cmd = (char*)wmalloc(strlen(str) + 10);
-        sprintf(cmd, "locate \"%s\"", str);
+        size_t cmdLen = strlen(str) + 10;
+        cmd = (char*)wmalloc(cmdLen);
+        snprintf(cmd, cmdLen, "locate \"%s\"", str);
     } else {
         char* path;
+        size_t cmdLen;
 
         path = FSGetFSViewerPath(finder->fsViewer);
-        cmd = (char*)wmalloc(strlen(str) + strlen(path) + 24);
+        cmdLen = strlen(str) + strlen(path) + 24;
+        cmd = (char*)wmalloc(cmdLen);
 
-        sprintf(cmd, "find \"%s\" -name \"%s\" -print", path, str);
+        snprintf(cmd, cmdLen, "find \"%s\" -name \"%s\" -print", path, str);
     }
 
     if ((f = popen(cmd, "r")) == NULL)

--- a/src/FSPanel.c
+++ b/src/FSPanel.c
@@ -6,6 +6,7 @@
 #include <WINGs/WINGsP.h>
 #include <X11/Xatom.h>
 #include <X11/keysym.h>
+#include <stdint.h>
 
 static FSSelectIconPanel* FSCreateSelectIconPanel(WMWindow*,
     char*, char*);
@@ -1125,7 +1126,7 @@ endedEditingObserver(void* observerData, WMNotification* notification)
     FSAppInputPanel* appInput = (FSAppInputPanel*)observerData;
     WMTextField* tPtr = (WMTextField*)WMGetNotificationObject(notification);
 
-    if ((int)WMGetNotificationClientData(notification) == WMReturnTextMovement
+    if ((int)(intptr_t)WMGetNotificationClientData(notification) == WMReturnTextMovement
         && tPtr == appInput->nameField) {
         char* txt = WMGetTextFieldText(appInput->nameField);
         if (strcmp("", txt)) {
@@ -1384,6 +1385,7 @@ FSCreateSelectIconPanel(WMWindow* owner, char* title, char* str)
     WMLabel* l;
     WMPixmap* pixmap;
     char* txt = NULL;
+    int txtAllocated = 0;
     WMFont* aFont;
 
     if (!(selIcon = (FSSelectIconPanel*)wmalloc(sizeof(FSSelectIconPanel))))
@@ -1397,6 +1399,8 @@ FSCreateSelectIconPanel(WMWindow* owner, char* title, char* str)
     txt = FSGetStringForName("ICONDIR");
     if (!txt)
         txt = ICONDIR;
+    else
+        txtAllocated = 1;
 
     selIcon->xpmDir = (char*)wmalloc(strlen(txt) + 5);
     strcpy(selIcon->xpmDir, txt);
@@ -1406,7 +1410,7 @@ FSCreateSelectIconPanel(WMWindow* owner, char* title, char* str)
     strcpy(selIcon->pngDir, txt);
     strcat(selIcon->pngDir, "/png");
 
-    if (txt != ICONDIR)
+    if (txtAllocated)
         free(txt);
 
     height = 422;

--- a/src/FSPathView.c
+++ b/src/FSPathView.c
@@ -179,7 +179,7 @@ void FSSetPathViewMaxVisibleColumns(FSPathView* pvPtr, int columns)
     int curMaxVisibleColumns;
     int newFirstVisibleColumn = 0;
 
-    assert((int)pvPtr);
+    assert(pvPtr);
 
     columns = (columns < MIN_VISIBLE_COLUMNS) ? MIN_VISIBLE_COLUMNS : columns;
     columns = (columns > MAX_VISIBLE_COLUMNS) ? MAX_VISIBLE_COLUMNS : columns;
@@ -262,7 +262,7 @@ removeColumn(FSPathView* pvPtr, int column)
     FSFileButton** clist;
     char** tlist;
 
-    assert((int)pvPtr);
+    assert(pvPtr);
 
     column = (column < 0) ? 0 : column;
     if (column >= pvPtr->columnCount) {
@@ -452,6 +452,8 @@ scrollCallback(WMWidget* scroller, void* self)
 
     } break;
 
+    case WSDecrementWheel:
+    case WSIncrementWheel:
     case WSKnobSlot:
     case WSNoPart:
         /* do nothing */

--- a/src/FSUtils.c
+++ b/src/FSUtils.c
@@ -575,9 +575,8 @@ void FSSetButtonImageFromFile(WMButton* btn, char* imgName)
     }
 
     if (imgName) {
-        WMColor* white = WMWhiteColor(WMWidgetScreen(btn));
-        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(btn), imgName, white);
-        WMReleaseColor(white);
+        RColor white = { 0xff, 0xff, 0xff, 0xff };
+        pixmap = WMCreateBlendedPixmapFromFile(WMWidgetScreen(btn), imgName, &white);
     } else {
         pixmap = NULL;
     }

--- a/src/FSUtils.h
+++ b/src/FSUtils.h
@@ -20,7 +20,7 @@ WMPixmap* FSMakePixmap(WMScreen* sPtr, char** data, int width, int height);
 void FSErrorDialog(char* title, char* msg);
 int FSConfirmationDialog(char* title, char* msg);
 mode_t FSGetUMask();
-void FSUpdateFileView();
+void FSUpdateFileView(FileAction action, FileInfo* src, FileInfo* dest);
 char* FSGetHomeDir();
 int FSStringMatch(char* pattern, char* fn);
 WMPixmap* FSCreateBlendedPixmapFromFile(WMScreen* scr, char* fileName, WMColor* color);

--- a/src/extnInspector.c
+++ b/src/extnInspector.c
@@ -1,6 +1,7 @@
 #include "FSPanel.h"
 #include "FSUtils.h"
 #include "FSViewer.h"
+#include <stdint.h>
 
 #define WIDTH 272
 #define HEIGHT 272
@@ -342,7 +343,7 @@ endedEditingObserver(void* observerData, WMNotification* notification)
 {
     Panel* panel = (Panel*)observerData;
 
-    if ((int)WMGetNotificationClientData(notification) == WMReturnTextMovement) {
+    if ((int)(intptr_t)WMGetNotificationClientData(notification) == WMReturnTextMovement) {
         WMPerformButtonClick(panel->addBtn);
     }
 }

--- a/src/magic.c
+++ b/src/magic.c
@@ -38,12 +38,12 @@ static int hdrbufsiz = 0; /* Size of header buffer. */
 static struct stat stbuf; /* Stat buffer. */
 static struct stat lstbuf; /* Lstat buffer. */
 static int bytes; /* Bytes read from the file. */
-static int mmatch();
-static char* builtin_test();
+static int mmatch(int i, char* buf);
+static char* builtin_test(void);
 static char* builtin_result;
-static char* parse_string();
+static char* parse_string(char** s);
 
-void magic_parse_file(name) char* name;
+void magic_parse_file(char* name)
 {
     FILE* fh;
     int hsiz;
@@ -211,8 +211,7 @@ void magic_parse_file(name) char* name;
     }
 }
 
-void magic_get_type(name, buf) char* name;
-char* buf;
+void magic_get_type(char* name, char* buf)
 {
     int i;
     int fd;
@@ -273,9 +272,7 @@ char* buf;
     strcpy(buf, builtin_test());
 }
 
-static int mmatch(i, buf)
-int i;
-char* buf;
+static int mmatch(int i, char* buf)
 {
     int t;
     int o;
@@ -424,8 +421,7 @@ static char* builtin_test()
     return builtin_result = "unreadable";
 }
 
-static char* parse_string(s)
-char** s;
+static char* parse_string(char** s)
 {
     char cbuf[4];
     int i;

--- a/src/regexp/regerror.c
+++ b/src/regexp/regerror.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 void
-    regerror(s) char* s;
+regerror(char* s)
 {
     fprintf(stderr, "regexp(3): %s", s);
 }

--- a/src/regexp/regexp.c
+++ b/src/regexp/regexp.c
@@ -160,18 +160,18 @@ static long regsize; /* Code size. */
 #ifndef STATIC
 #define STATIC static
 #endif
-STATIC char* reg();
-STATIC char* regbranch();
-STATIC char* regpiece();
-STATIC char* regatom();
-STATIC char* regnode();
-STATIC char* regnext();
-STATIC void regc();
-STATIC void reginsert();
-STATIC void regtail();
-STATIC void regoptail();
+STATIC char* reg(int paren, int* flagp);
+STATIC char* regbranch(int* flagp);
+STATIC char* regpiece(int* flagp);
+STATIC char* regatom(int* flagp);
+STATIC char* regnode(char op);
+STATIC char* regnext(char* p);
+STATIC void regc(char b);
+STATIC void reginsert(char op, char* opnd);
+STATIC void regtail(char* p, char* val);
+STATIC void regoptail(char* p, char* val);
 #ifdef STRCSPN
-STATIC int strcspn();
+STATIC int strcspn(char* s1, char* s2);
 #endif
 
 /*
@@ -190,8 +190,7 @@ STATIC int strcspn();
  * of the structure of the compiled regexp.
  */
 regexp*
-regcomp(exp)
-char* exp;
+regcomp(char* exp)
 {
     register regexp* r;
     register char* scan;
@@ -278,9 +277,7 @@ char* exp;
  * follows makes it hard to avoid.
  */
 static char*
-reg(paren, flagp)
-int paren; /* Parenthesized? */
-int* flagp;
+reg(int paren, int* flagp)
 {
     register char* ret;
     register char* br;
@@ -350,8 +347,7 @@ int* flagp;
  * Implements the concatenation operator.
  */
 static char*
-regbranch(flagp)
-int* flagp;
+regbranch(int* flagp)
 {
     register char* ret;
     register char* chain;
@@ -389,8 +385,7 @@ int* flagp;
  * endmarker role is not redundant.
  */
 static char*
-regpiece(flagp)
-int* flagp;
+regpiece(int* flagp)
 {
     register char* ret;
     register char op;
@@ -453,8 +448,7 @@ int* flagp;
  * separate node; the code is simpler that way and it's not worth fixing.
  */
 static char*
-regatom(flagp)
-int* flagp;
+regatom(int* flagp)
 {
     register char* ret;
     int flags;
@@ -560,8 +554,7 @@ int* flagp;
  - regnode - emit a node
  */
 static char* /* Location. */
-regnode(op)
-char op;
+regnode(char op)
 {
     register char* ret;
     register char* ptr;
@@ -585,7 +578,7 @@ char op;
  - regc - emit (if appropriate) a byte of code
  */
 static void
-    regc(b) char b;
+regc(char b)
 {
     if (regcode != &regdummy)
         *regcode++ = b;
@@ -599,8 +592,7 @@ static void
  * Means relocating the operand.
  */
 static void
-    reginsert(op, opnd) char op;
-char* opnd;
+reginsert(char op, char* opnd)
 {
     register char* src;
     register char* dst;
@@ -627,8 +619,7 @@ char* opnd;
  - regtail - set the next-pointer at the end of a node chain
  */
 static void
-    regtail(p, val) char* p;
-char* val;
+regtail(char* p, char* val)
 {
     register char* scan;
     register char* temp;
@@ -658,8 +649,7 @@ char* val;
  - regoptail - regtail on operand of first argument; nop if operandless
  */
 static void
-    regoptail(p, val) char* p;
-char* val;
+regoptail(char* p, char* val)
 {
     /* "Operandless" and "op != BRANCH" are synonymous in practice. */
     if (p == NULL || p == &regdummy || OP(p) != BRANCH)
@@ -682,9 +672,9 @@ static char** regendp; /* Ditto for endp. */
 /*
  * Forwards.
  */
-STATIC int regtry();
-STATIC int regmatch();
-STATIC int regrepeat();
+STATIC int regtry(regexp* prog, char* string);
+STATIC int regmatch(char* prog);
+STATIC int regrepeat(char* p);
 
 #ifdef DEBUG
 int regnarrate = 0;
@@ -695,9 +685,7 @@ STATIC char* regprop();
 /*
  - regexec - match a regexp against a string
  */
-int regexec(prog, string)
-register regexp* prog;
-register char* string;
+int regexec(regexp* prog, char* string)
 {
     register char* s;
     /* 	extern char *strchr(); */
@@ -757,9 +745,7 @@ register char* string;
  - regtry - try match at specific point
  */
 static int /* 0 failure, 1 success */
-regtry(prog, string)
-regexp* prog;
-char* string;
+regtry(regexp* prog, char* string)
 {
     register int i;
     register char** sp;
@@ -794,8 +780,7 @@ char* string;
  * by recursion.
  */
 static int /* 0 failure, 1 success */
-regmatch(prog)
-char* prog;
+regmatch(char* prog)
 {
     register char* scan; /* Current node. */
     char* next; /* Next node. */
@@ -977,8 +962,7 @@ char* prog;
  - regrepeat - repeatedly match something simple, report how many
  */
 static int
-regrepeat(p)
-char* p;
+regrepeat(char* p)
 {
     register int count = 0;
     register char* scan;
@@ -1023,8 +1007,7 @@ char* p;
  - regnext - dig the "next" pointer out of a node
  */
 static char*
-regnext(p)
-register char* p;
+regnext(char* p)
 {
     register int offset;
 

--- a/src/regexp/regexp.h
+++ b/src/regexp/regexp.h
@@ -51,7 +51,7 @@ typedef struct regexp {
 	char program[1];	/* Unwarranted chumminess with compiler. */
 } regexp;
 
-extern regexp *regcomp();
-extern int regexec();
-extern void regsub();
-extern void regerror();
+extern regexp *regcomp(char *exp);
+extern int regexec(regexp *prog, char *string);
+extern void regsub(regexp *prog, char *source, char *dest);
+extern void regerror(char *s);

--- a/src/regexp/regsub.c
+++ b/src/regexp/regsub.c
@@ -32,10 +32,7 @@
  - regsub - perform substitutions after a regexp match
  */
 void
-    regsub(prog, source, dest)
-        regexp* prog;
-char* source;
-char* dest;
+regsub(regexp* prog, char* source, char* dest)
 {
     register char* src;
     register char* dst;

--- a/src/xmodifier.c
+++ b/src/xmodifier.c
@@ -31,6 +31,7 @@ along with XEmacs; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
 
+#include <X11/XKBlib.h>
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include <string.h>
@@ -170,7 +171,7 @@ x_reset_modifier_mapping(Display* display)
             for (column = 0; column < 4; column += 2) {
                 KeyCode code = x_modifier_keymap->modifiermap[modifier_index * mkpm
                     + modifier_key];
-                KeySym sym = (code ? XKeycodeToKeysym(display, code, column) : 0);
+                KeySym sym = (code ? XkbKeycodeToKeysym(display, code, 0, column) : 0);
                 if (sym == last_sym)
                     continue;
                 last_sym = sym;


### PR DESCRIPTION
The build produced >100 warnings across the tree, dominated by undefined-behavior
casts, K&R-style function declarations, and a deprecated X11 API. This PR fixed that:

### Pointer/int casts (`-Wpointer-to-int-cast`, `-Wvoid-pointer-to-int-cast`)
- `FSBrowser.c`, `FSPathView.c`: drop bogus `assert((int)ptr)` casts that
  truncate on 64-bit; the assertion only needs the pointer.
- `FSBrowser.c`, `FSFinder.c`, `FSPanel.c`, `extnInspector.c`: route
  `WMGetNotificationClientData(...)` through `intptr_t` before narrowing to
  `int`.

### Switch coverage (`-Wswitch`)
- `FSBrowser.c`, `FSPathView.c`: add `WSDecrementWheel` / `WSIncrementWheel`
  cases (no-op, matching the existing `WSKnobSlot` / `WSNoPart` arm).
- `FSFileView.c`: handle `FileLink` in `FSUpdateFileViewPath`; treated like
  `FileCopy` since it introduces a new entry into the view.

### Missing prototypes (`-Wdeprecated-non-prototype`)
- `FSUtils.h`: give `FSUpdateFileView` a real prototype (was `()`).
- `magic.c`, `regexp/regexp.c`, `regexp/regsub.c`, `regexp/regerror.c`,
  `regexp/regexp.h`: convert all K&R declarations and definitions to ANSI
  prototypes. Pure mechanical rewrite; no behavior change.

### Misc
- `FSFileView.c`: drop extraneous parens in `if ((x == y))`
  (`-Wparentheses-equality`).
- `FSUtils.c`: replace `WMColor*` with an `RColor` literal in the call to
  `WMCreateBlendedPixmapFromFile`, which actually takes `const RColor*`
  (`-Wincompatible-pointer-types`).
- `FSPanel.c`: replace `if (txt != ICONDIR)` pointer-literal compare with an
  explicit "allocated" flag (`-Wstring-compare`).
- `xmodifier.c`: replace deprecated `XKeycodeToKeysym` with
  `XkbKeycodeToKeysym` (`-Wdeprecated-declarations`).
